### PR TITLE
[Decision] Keep the same jobname in CentOS CI as before the repo was retitled?

### DIFF
--- a/.cico.yaml
+++ b/.cico.yaml
@@ -4,7 +4,7 @@
         - timed: "@daily"
 
 - job-template:
-    name: '{ci_project}-{ci_project_name}'
+    name: '{ci_project}-{ci_job_name}'
     description: |
         Managed by Jenkins Job Builder, do not edit manually!
     properties:
@@ -28,7 +28,7 @@
 - project:
     name: fedora-qa
     jobs:
-        - '{ci_project}-{ci_project_name}':
+        - '{ci_project}-{ci_job_name}':
             git_username: fedora-modularity
             git_repo: compose-tests
             ci_job_name: compose_tester

--- a/.cico.yaml
+++ b/.cico.yaml
@@ -31,5 +31,5 @@
         - '{ci_project}-{ci_project_name}':
             git_username: fedora-modularity
             git_repo: compose-tests
-            ci_job_name: compose-tester
+            ci_job_name: compose_tester
             ci_project: fedora-qa

--- a/.cico.yaml
+++ b/.cico.yaml
@@ -4,7 +4,7 @@
         - timed: "@daily"
 
 - job-template:
-    name: '{ci_project}-{git_repo}'
+    name: '{ci_project}-{ci_project_name}'
     description: |
         Managed by Jenkins Job Builder, do not edit manually!
     properties:
@@ -28,7 +28,8 @@
 - project:
     name: fedora-qa
     jobs:
-        - '{ci_project}-{git_repo}':
+        - '{ci_project}-{ci_project_name}':
             git_username: fedora-modularity
             git_repo: compose-tests
+            ci_job_name: compose-tester
             ci_project: fedora-qa


### PR DESCRIPTION
Previously we had the job located here:
https://ci.centos.org/job/fedora-qa-compose_tester/

Since the name of the repo was changed to `compose-tests`, a new job is created here:
https://ci.centos.org/job/fedora-qa-compose-tests/

Accepting this PR would go back to using the old job name. Rejecting this PR will allow you to use the new job name. Whichever you choose, I'll go back and delete the other one.